### PR TITLE
Fixing volume being set on page init.

### DIFF
--- a/public/video-js/video.dev.js
+++ b/public/video-js/video.dev.js
@@ -4658,7 +4658,7 @@ vjs.Html5.prototype.duration = function(){ return this.el_.duration || 0; };
 vjs.Html5.prototype.buffered = function(){ return this.el_.buffered; };
 
 vjs.Html5.prototype.volume = function(){ return this.el_.volume; };
-vjs.Html5.prototype.setVolume = function(percentAsDecimal){ this.el_.volume = percentAsDecimal; };
+vjs.Html5.prototype.setVolume = function(percentAsDecimal){ this.el_.volume = percentAsDecimal || 0; };
 vjs.Html5.prototype.muted = function(){ return this.el_.muted; };
 vjs.Html5.prototype.setMuted = function(muted){ this.el_.muted = muted; };
 


### PR DESCRIPTION
When volume has never been set, fallback to muted (0) so as not to cause an error.
