### PR TITLE
Make so copy paste doesn’t get fractal loop’s fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Homebrew is recommended for OS X users.
 
 Once you have them installed, go ahead and clone the repository.
 
-    git clone git@github.com:fractaloop/soundtrack.io.git
+    git clone git@github.com:martindale/soundtrack.io.git
     cd soundtrack.io
 
 You will need to fetch the dependencies and then you can start up the server.


### PR DESCRIPTION
Copying and pasting the git clone command in install instructions clones fractal loops copy
Accidentally did this a few times
